### PR TITLE
fix: logout error

### DIFF
--- a/web/src/components/Header.tsx
+++ b/web/src/components/Header.tsx
@@ -31,14 +31,14 @@ const HeaderUserInfo: React.FC = () => {
       {user && (
         <UI.Button
           variant="outline"
-          variantcolor="blackAlpha"
+          colorScheme="blackAlpha"
           onClick={signOut}
         >
           Logout
         </UI.Button>
       )}
       {!user && (
-        <UI.Button variant="outline" variantColor="blackAlpha" onClick={signIn}>
+        <UI.Button variant="outline" colorScheme="blackAlpha" onClick={signIn}>
           Login
         </UI.Button>
       )}


### PR DESCRIPTION
chakra v1 以降 variantColor属性がcolorScheme属性にリネームされているため、ログアウト時にエラーになっていました。

https://chakra-ui.com/docs/migration#3-rename-variantcolor-to-colorscheme