### PR TITLE
fix: cached files give 404 Not found error

### DIFF
--- a/web/public/worker/serviceWorker.js
+++ b/web/public/worker/serviceWorker.js
@@ -10,12 +10,6 @@ self.addEventListener('fetch', function (event) {
         return response;
       } else {
         return fetch(event.request).then(function (response) {
-          // Response can be used only once:
-          // we have to make a clone to the response and put the first copy to the cache, then return the last copy to the client.
-          let responseClone = response.clone();
-          caches.open(CACHE_NAME).then(function (cache) {
-            cache.put(event.request, responseClone);
-          });
           return response;
         });
       }

--- a/web/scripts/setup-viewer.js
+++ b/web/scripts/setup-viewer.js
@@ -8,6 +8,8 @@ fs.copySync(viewerPath, 'public/viewer', {
   overwrite: true
 })
 
+fs.copyFileSync('public/worker/serviceWorker.js','public/viewer/serviceWorker.js')
+
 const jspath = 'public/viewer/js/vivliostyle-viewer.js'
 const jsData = fs.readFileSync(jspath, 'utf8')
 const newJsData = jsData.replace(/"HEAD"/g, '"GET" ')
@@ -26,7 +28,7 @@ const newHtmlData = htmlData
   .replace(/<\/head>/g,`  <script>
       if ("serviceWorker" in navigator) {
         window.addEventListener("load", function () {
-          navigator.serviceWorker.register("/worker/serviceWorker.js").then(
+          navigator.serviceWorker.register("/viewer/serviceWorker.js").then(
             function (registration) {
               // Registration was successful
               console.log(


### PR DESCRIPTION
Cache Storageにキャッシュしたファイルがviewerで404になる原因は、Service Workerのスコープの問題でした。

参考: [ServiceWorker のスコープとページコントロールについて](https://qiita.com/nhiroki/items/eb16b802101153352bba)

Service WorkerのスコープがserviceWorker.jsのある/wokerになるため 、スコープが異なる/viewer/index.htmlでXMLHttpRequestを使用してもfetchイベントをフックできない状態でした。
そこで、serviceWorker.jsをsetup-viewer.jsでviewer/にコピーすることでスコープを/viewerに揃えました。

また、serviceWorker.js内でキャッシュにヒットしなかった全てのファイルをキャッシュする処理はキャッシュサイズの増大を招くため削除しました。
