### PR TITLE
fix: コンテンツの準備が出来ていないときにプレビューが404になる不具合

### DIFF
--- a/web/scripts/setup-viewer.js
+++ b/web/scripts/setup-viewer.js
@@ -8,6 +8,7 @@ fs.copySync(viewerPath, 'public/viewer', {
   overwrite: true
 })
 
+fs.writeFileSync('public/viewer/empty.html','');
 fs.copyFileSync('public/worker/serviceWorker.js','public/viewer/serviceWorker.js')
 
 const jspath = 'public/viewer/js/vivliostyle-viewer.js'

--- a/web/src/components/MarkdownPreviewer.tsx
+++ b/web/src/components/MarkdownPreviewer.tsx
@@ -1,4 +1,4 @@
-import {useRef, useEffect, useMemo} from 'react';
+import {useRef, useEffect, useMemo, useState} from 'react';
 import {stringify} from '@vivliostyle/vfm';
 import path from 'path';
 import mime from 'mime-types'
@@ -69,9 +69,11 @@ export const Previewer: React.FC<PreviewerProps> = ({
   repo,
   user,
 }) => {
+  const [contentReady,setContentReady] = useState<boolean>(false);
   const iframeRef = useRef<HTMLIFrameElement>(null);
   // Why Date.now()? -> disable viewer cache
   const viewerURL = useMemo(() => {
+    setContentReady(false);
     let url = `${VIVLIOSTYLE_VIEWER_HTML_URL}?${Date.now()}#x=${path.join(VPUBFS_ROOT, basename)}`
     if(stylesheet) url += `&style=${isURL(stylesheet) ? stylesheet : path.join(VPUBFS_ROOT, stylesheet)}`
     return url
@@ -98,10 +100,9 @@ export const Previewer: React.FC<PreviewerProps> = ({
       })
 
       await Promise.all(imagePaths.map(imagePath => updateCacheFromPath(owner, repo, basename, imagePath, user)))
-
-      iframeRef.current?.contentWindow?.location.reload()
+      setContentReady(true);
     })()
   }, [body, basename, stylesheet, owner, repo, user]);
 
-  return <iframe ref={iframeRef} src={viewerURL} width="100%" height="100%"></iframe>;
+  return <iframe ref={iframeRef} src={contentReady?viewerURL:VIVLIOSTYLE_VIEWER_HTML_URL+'#x=empty.html'} width="100%" height="100%"></iframe>;
 };

--- a/web/src/pages/api/github/contentOfRepository.ts
+++ b/web/src/pages/api/github/contentOfRepository.ts
@@ -68,7 +68,8 @@ const contentOfRepository: NextApiHandler<ContentOfRepositoryApiResponse | null>
     const content = Array.isArray(data)? data[0] : data
     return res.send(data)
   } catch (error) {
-    throw error
+    const e = error as any;
+    return res.status(e.status).send(null);
   }
 };
 


### PR DESCRIPTION
#81 

コンテンツの準備が出来ていないときには空のHTMLファイルをvivliostyle viewerに渡すように変更しました。

将来的にはviewerのローディング表示に合わせるので暫定的な対応です。