### PR TITLE
feat: add browser-default theme

### DIFF
--- a/web/src/components/MarkdownPreviewer.tsx
+++ b/web/src/components/MarkdownPreviewer.tsx
@@ -55,7 +55,7 @@ const updateCacheFromPath = async(owner: string, repo: string, basePath: string,
 interface PreviewerProps {
   body: string;
   basename: string;
-  stylesheet?: string;
+  stylesheet?: string|null;
   owner: string;
   repo: string;
   user: firebase.User | null;

--- a/web/src/components/MarkdownPreviewer.tsx
+++ b/web/src/components/MarkdownPreviewer.tsx
@@ -55,7 +55,7 @@ const updateCacheFromPath = async(owner: string, repo: string, basePath: string,
 interface PreviewerProps {
   body: string;
   basename: string;
-  stylesheet?: string|null;
+  stylesheet: string|null;
   owner: string;
   repo: string;
   user: firebase.User | null;

--- a/web/src/pages/github/[owner]/[repo].tsx
+++ b/web/src/pages/github/[owner]/[repo].tsx
@@ -18,7 +18,7 @@ import {BranchSelecter} from '@components/BranchSelecter';
 
 const themes = [
   {
-    name: 'Browser Default',
+    name: 'Plain',
     css: null
   },
   {

--- a/web/src/pages/github/[owner]/[repo].tsx
+++ b/web/src/pages/github/[owner]/[repo].tsx
@@ -18,6 +18,10 @@ import {BranchSelecter} from '@components/BranchSelecter';
 
 const themes = [
   {
+    name: 'Browser Default',
+    css: null
+  },
+  {
     name: '縦書き小説',
     css:
       'https://vivliostyle.github.io/vivliostyle_doc/samples/gingatetsudo/style.css',
@@ -88,7 +92,7 @@ const GitHubOwnerRepo =  () => {
   const [status, setStatus] = useState<'init' | 'clean' | 'modified' | 'saved'>(
     'init',
   );
-  const [stylesheet, setStylesheet] = useState<string>(themes[2].css);
+  const [stylesheet, setStylesheet] = useState<string|null>(themes[0].css);
   const [isProcessing, setIsProcessing] = useState<boolean>(false);
   const [buildID, setBuildID] = useState<string | null>(null);
   const toast = useToast();
@@ -189,7 +193,7 @@ const GitHubOwnerRepo =  () => {
       });
   }
 
-  function onThemeSelected(themeURL: string) {
+  function onThemeSelected(themeURL: string|null) {
     setStylesheet(themeURL);
   }
 
@@ -275,7 +279,7 @@ const GitHubOwnerRepo =  () => {
                       key={theme.name}
                       onClick={() => onThemeSelected(theme.css)}
                     >
-                      {theme.name}
+                      {theme.css == stylesheet?'✔ ':' '}{theme.name}
                     </UI.MenuItem>
                   ))}
                 </UI.MenuGroup>


### PR DESCRIPTION
fix #119 

CSSを使用せず、ブラウザデフォルトのスタイルを使用する「Browser Default」テーマをメニュー項目に追加し、デフォルトテーマとしました。

現在選択しているテーマのメニュー項目にチェックを付けるよう変更しました。