### PR TITLE
ブランチ切り替えでの不具合修正

### DIFF
--- a/web/src/pages/github/[owner]/[repo].tsx
+++ b/web/src/pages/github/[owner]/[repo].tsx
@@ -334,7 +334,7 @@ const GitHubOwnerRepo =  () => {
             </UI.Box>)
             :''}
             <UI.Box width={isPresentationMode ? '100%' : '40%'} overflow="scroll">
-              <Previewer basename={filePath.replace(/\.md$/, '.html')} body={text} stylesheet={stylesheet} owner={ownerStr!} repo={repoStr!} user={user} />
+              <Previewer basename={filePath.replace(/\.md$/, '.html')} body={text} stylesheet={stylesheet} owner={ownerStr!} repo={repoStr!} branch={branch!} user={user} />
             </UI.Box>
           </UI.Flex>
         ) : (

--- a/web/src/pages/github/[owner]/[repo].tsx
+++ b/web/src/pages/github/[owner]/[repo].tsx
@@ -219,8 +219,10 @@ const GitHubOwnerRepo =  () => {
   }, [filenames, filenamesFilterText])
 
   useEffect(() => {
-    if(config && config.theme) setStylesheet(config.theme)
-  }, [config])
+    if(config){
+      setStylesheet(config.theme??'');
+    }
+  }, [config]);
 
   const {
     isOpen:isOpenFileUploadModal,


### PR DESCRIPTION
2つの不具合を修正します。

1. ブランチを切り替えた際に、元のブランチのvivliostyle.config.jsでthemeが指定されていて、切り替えたブランチのvivliostyle.config.jsでthemeが指定されていない場合、stylesheetがリセットされない不具合
2. MarkdownPreviewerにbranchが渡されずgetContentで取得するファイルが全てデフォルトブランチのものになっていたため、その他のブランチのみに存在する画像ファイルは取得できない不具合。