### PR TITLE
fix #168 

### DIFF
--- a/.github/workflows/deploy-cloud-run.yml
+++ b/.github/workflows/deploy-cloud-run.yml
@@ -52,3 +52,4 @@ jobs:
             --memory 8Gi \
             --concurrency 1 \
             --quiet
+          gcloud run services update-traffic vivliostyle-pub-build-pdf --to-latest

--- a/.github/workflows/deploy-cloud-run.yml
+++ b/.github/workflows/deploy-cloud-run.yml
@@ -3,7 +3,7 @@ name: Delivery Containers
 on:
   push:
     branches:
-      - migrate-cloudrun-to-latest-version
+      - master
 
 env:
   GCP_REGION: asia-northeast1

--- a/.github/workflows/deploy-cloud-run.yml
+++ b/.github/workflows/deploy-cloud-run.yml
@@ -52,4 +52,6 @@ jobs:
             --memory 8Gi \
             --concurrency 1 \
             --quiet
-          gcloud run services update-traffic vivliostyle-pub-build-pdf --to-latest
+          gcloud run services update-traffic vivliostyle-pub-build-pdf --to-latest \
+            --region $GCP_REGION \
+            --platform managed \

--- a/.github/workflows/deploy-cloud-run.yml
+++ b/.github/workflows/deploy-cloud-run.yml
@@ -3,7 +3,7 @@ name: Delivery Containers
 on:
   push:
     branches:
-      - master
+      - migrate-cloudrun-to-latest-version
 
 env:
   GCP_REGION: asia-northeast1


### PR DESCRIPTION
fix #168 

デプロイ時に migrate traffic されていないという現象が発生していたため、問題が発生していました。
つまりは、デプロイされた最新の Container ではなく古いコンテナにアクセスされるような設定になっていました。
これを直したので、 Vivliostyle CLI は新しいものを参照するようになったはずです。