### PR TITLE
Change build result path of firestore

### DIFF
--- a/.github/workflows/deploy-cloud-run.yml
+++ b/.github/workflows/deploy-cloud-run.yml
@@ -3,7 +3,7 @@ name: Delivery Containers
 on:
   push:
     branches:
-      - master
+      - change-build-result-path-of-firestore
 
 env:
   GCP_REGION: asia-northeast1

--- a/.github/workflows/deploy-cloud-run.yml
+++ b/.github/workflows/deploy-cloud-run.yml
@@ -3,7 +3,7 @@ name: Delivery Containers
 on:
   push:
     branches:
-      - change-build-result-path-of-firestore
+      - master
 
 env:
   GCP_REGION: asia-northeast1

--- a/cloud-run/src/index.ts
+++ b/cloud-run/src/index.ts
@@ -89,14 +89,15 @@ app.post('/', async (req, res) => {
       repo: string;
       themeName: string;
       httpMode: boolean;
+      uid: string;
       id: string;
     }
     const buidRequest: BuidRequest = JSON.parse(
       Buffer.from(req.body.message.data, 'base64').toString(),
     );
-    const url = await buildAndUpload(buidRequest.owner, buidRequest.repo, buidRequest.themeName, buidRequest.httpMode);
-    if (buidRequest.id) await firestore.collection('builds').doc(buidRequest.id).update(url);
-    console.log('>> Complete build: ' + url.signedUrl);
+    const uploadFileResult = await buildAndUpload(buidRequest.owner, buidRequest.repo, buidRequest.themeName, buidRequest.httpMode);
+    if (buidRequest.id) await firestore.doc(`users/${buidRequest.uid}/builds/${buidRequest.id}`).update(uploadFileResult);
+    console.log('>> Complete build: ' + uploadFileResult.signedUrl);
     res.status(204).send();
   } catch (error) {
     console.error(`error: ${error}`);

--- a/firestore/firestore.rules
+++ b/firestore/firestore.rules
@@ -12,6 +12,10 @@ service cloud.firestore {
           && request.resource.data.owner == resource.data.owner
           && request.resource.data.repo == resource.data.repo;
       }
+
+      match /builds/{buildId} {
+        allow read: if authenticated(userId);
+      }
     }
 
     function authenticated(userId) {

--- a/functions/src/buildPdf/index.ts
+++ b/functions/src/buildPdf/index.ts
@@ -16,7 +16,7 @@ const publishMessage = async(topicName:string, data:any) => {
 }
 
 export const buildPDF = functions.https.onCall(async(repoInfo, context) => {
-  const ref = await firestore.collection('builds').add({
+  const ref = await firestore.collection(`users/${context.auth?.uid}/builds`).add({
     url: null, 
     repo: repoInfo
   });
@@ -25,7 +25,8 @@ export const buildPDF = functions.https.onCall(async(repoInfo, context) => {
     repo: repoInfo.repo,
     themeName: repoInfo.themeName,
     httpMode: repoInfo.httpMode,
-    id: ref.id
+    uid: context.auth?.uid,
+    id: ref.id,
   });
   return { buildID : ref.id };
 })

--- a/web/src/pages/github/[owner]/[repo].tsx
+++ b/web/src/pages/github/[owner]/[repo].tsx
@@ -35,36 +35,6 @@ interface BuildRecord {
   };
 }
 
-function useBuildStatus(
-  buildID: string | null,
-  onBuildFinished?: (artifactURL: string) => void,
-) {
-  useEffect(() => {
-    if (!buildID) return;
-    console.log('useBuildStatus', buildID);
-    const unsubscribe = onSnapshot(doc(db, 'builds', buildID), (doc) => {
-      const {signedUrl} = doc.data() as BuildRecord;
-      console.log('Current data: ', doc.data());
-      if (!signedUrl) return;
-      unsubscribe();
-      console.log('buildStatus unsubscribed', unsubscribe);
-      if (onBuildFinished) onBuildFinished(signedUrl);
-    });
-
-    // const unsubscribe = firebase
-    //   .firestore()
-    //   .collection('builds')
-    //   .doc(buildID)
-    //   .onSnapshot(function (doc) {
-    //     const {url} = doc.data() as BuildRecord;
-    //     console.log('Current data: ', doc.data());
-    //     if (!url) return;
-    //     unsubscribe();
-    //     if (onBuildFinished) onBuildFinished(url);
-    //   });
-    // return unsubscribe;
-  }, [buildID, onBuildFinished]);
-}
 
 /**
  * メインコンポーネント
@@ -118,32 +88,25 @@ const GitHubOwnerRepo = () => {
   const setWarnDialog = useWarnBeforeLeaving();
   const [isPresentationMode, setPresentationMode] = useState<boolean>(false);
 
-  useBuildStatus(buildID, (artifactURL: string) => {
-    setIsProcessing(false);
-    // const ViewPDFToast = ({onClose}: RenderProps) => (
-    //   <UI.Box bg="tomato" p={5} color="white">
-    //     <UI.Link href={artifactURL} isExternal onClick={onClose}>
-    //       View PDF
-    //     </UI.Link>
-    //   </UI.Box>
-    // );
-    console.log('build complete:' + artifactURL);
-    log.success(
-      <UI.Text>
-        {t('以下のリンクをクリックして表示してください')}
-        <UI.Link href={artifactURL} isExternal textDecoration={'underline'}>
-          View PDF
-        </UI.Link>
-      </UI.Text>,
-      5000,
-    ); // TODO リンクにする
-    setBuildID(null);
-    // toast({
-    //   duration: 9000,
-    //   isClosable: true,
-    //   render: ViewPDFToast,
-    // });
-  });
+  useEffect(() => {
+    if (!buildID) return;
+    const unsubscribe = onSnapshot(doc(db, 'builds', buildID), (doc) => {
+      const {signedUrl} = doc.data() as BuildRecord;
+      if (!signedUrl) return;
+      unsubscribe();
+      setIsProcessing(false);
+      log.success(
+        <UI.Text>
+          {t('以下のリンクをクリックして表示してください')}
+          <UI.Link href={signedUrl} isExternal textDecoration={'underline'}>
+            View PDF
+          </UI.Link>
+        </UI.Text>,
+        5000,
+      );
+      setBuildID(null);
+    });
+  }, [buildID]);
 
   // set text
   // useEffect(() => {

--- a/web/src/pages/github/[owner]/[repo].tsx
+++ b/web/src/pages/github/[owner]/[repo].tsx
@@ -89,8 +89,8 @@ const GitHubOwnerRepo = () => {
   const [isPresentationMode, setPresentationMode] = useState<boolean>(false);
 
   useEffect(() => {
-    if (!buildID) return;
-    const unsubscribe = onSnapshot(doc(db, 'builds', buildID), (doc) => {
+    if (!buildID || !app.state.user) return;
+    const unsubscribe = onSnapshot(doc(db, `users/${app.state.user.uid}/builds/${buildID}`), (doc) => {
       const {signedUrl} = doc.data() as BuildRecord;
       if (!signedUrl) return;
       unsubscribe();
@@ -106,7 +106,7 @@ const GitHubOwnerRepo = () => {
       );
       setBuildID(null);
     });
-  }, [buildID]);
+  }, [buildID, app.state.user]);
 
   // set text
   // useEffect(() => {


### PR DESCRIPTION
firebase rules に問題があって、他人の PDF Export 結果を閲覧できてしまう問題があったので直しました。

もともと PDF Export の結果が `builds/${buildID}` に入っていたのですが、これだと uid によるアクセス制御が難しかったのか、全員がアクセスできるような実装になっていたようです。（リポジトリ上だと違ったのですが、そういったルールが適用されていました）
そこで、PDF Export の結果を `users/${uid}/builds/${buildID}` に保存するようにし、 uid が一致するユーザしか参照できないようなアクセス制御を施しました。

ちなみに Export とか build とかバラバラで良くないので、 Export に統一がいいかなあとか考えています。