### PR TITLE
fix: Failed to parse vivliostyle.config.js when comments exist

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -34,6 +34,7 @@
     "i18next": "^21.6.10",
     "i18next-browser-languagedetector": "^6.1.3",
     "isomorphic-unfetch": "^3.1.0",
+    "json5": "^2.2.1",
     "lodash": "^4.17.21",
     "micro": "^9.3.4",
     "micro-cors": "^0.1.1",

--- a/web/src/middlewares/themes/CustomTheme.ts
+++ b/web/src/middlewares/themes/CustomTheme.ts
@@ -4,6 +4,7 @@ import { RepositoryContext } from "../contexts/useRepositoryContext";
 import { VivliostyleConfigSchema } from "../vivliostyle.config";
 import { WebApiFs } from "../fs/WebApiFS";
 import upath from "upath";
+import JSON5 from "json5";
 
 /**
  * CSSからアプリケーションキャッシュの対象になるファイルのリストアップ
@@ -134,13 +135,10 @@ export class CustomTheme implements Theme {
       // console.log('CustomTheme::create configString', configString);
       // 設定ファイルからthemeを取得
       // TODO: entry別のテーマ
-      const configJsonString = configString
-        .replace('module.exports = ', '')
-        .replaceAll(/^\s*(.+):/gm, '"$1":')
-        .replaceAll(`'`, '"')
-        .replaceAll(/,[\s\n]*([\]}])/g, '$1')
-        .replaceAll(/};/g, '}');
-      const config = JSON.parse(configJsonString) as VivliostyleConfigSchema;
+      const configJson5String = configString
+        .replace(/^([^\{\/]|\/\/[^\n]*(\n|$)|\/\*.*?\*\/)*\{/s, '{')
+        .replace(/\}([^\}\/]|\/\/[^\n]*(\n|$)|\/\*.*?\*\/)*$/s, '}');
+      const config = JSON5.parse(configJson5String) as VivliostyleConfigSchema;
       if (!config || !config.theme) {
         return null;
       }

--- a/web/src/middlewares/useVivliostyleConfig.ts
+++ b/web/src/middlewares/useVivliostyleConfig.ts
@@ -1,4 +1,5 @@
 import {useEffect, useState} from 'react';
+import JSON5 from 'json5';
 
 import type {VivliostyleConfigSchema} from './vivliostyle.config'
 import { User } from 'firebase/auth';
@@ -27,14 +28,11 @@ const parseConfig = (configString: string) => {
   // 
 
   console.log('config',configString);
-  const configJsonString = configString
-    .replace('module.exports = ', '')
-    .replaceAll(/^\s*(.+):/gm, '"$1":')
-    .replaceAll(`'`, '"')
-    .replaceAll(/,[\s\n]*([\]}])/g, "$1")
-    .replaceAll(/};/g, "}")
-    
-  return JSON.parse(configJsonString) as VivliostyleConfigSchema;
+  const configJson5String = configString
+    .replace(/^([^\{\/]|\/\/[^\n]*(\n|$)|\/\*.*?\*\/)*\{/s, '{')
+    .replace(/\}([^\}\/]|\/\/[^\n]*(\n|$)|\/\*.*?\*\/)*$/s, '}');
+
+  return JSON5.parse(configJson5String) as VivliostyleConfigSchema;
 };
 
 export function useVivlioStyleConfig({

--- a/web/yarn.lock
+++ b/web/yarn.lock
@@ -5758,6 +5758,11 @@ json5@^2.1.2:
   dependencies:
     minimist "^1.2.5"
 
+json5@^2.2.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/json5/-/json5-2.2.1.tgz#655d50ed1e6f95ad1a3caababd2b0efda10b395c"
+  integrity sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==
+
 jsonfile@^6.0.1:
   version "6.1.0"
   resolved "https://registry.yarnpkg.com/jsonfile/-/jsonfile-6.1.0.tgz#bc55b2634793c679ec6403094eb13698a6ec0aae"


### PR DESCRIPTION
- fix #169

create-book や `vivliostyle init` で生成されるコメントが入った vivliostyle.config.js でパースに失敗しないようにしました。

[JSON5](https://json5.org/) を使ってます。