### PR TITLE
lock vivliostyle/cli image's version

### DIFF
--- a/cloud-run/Dockerfile
+++ b/cloud-run/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/vivliostyle/cli:latest
+FROM ghcr.io/vivliostyle/cli:5.1.0
 LABEL maintainer "Vivliostyle Foundation <mail@vivliostyle.org>"
 
 RUN set -x \


### PR DESCRIPTION
## Why

ここら辺の問題が発生する要因として、 Pub の開発者が感知できないタイミングで vivliostyle/cli image の latest が変化されていたからです。
https://github.com/vivliostyle/vivliostyle-pub/issues/190

latest を参照している以上、同様の問題が今後も発生します。

## What & How

現在の latest は `ghcr.io/vivliostyle/cli:5.1.0` なので、それを参照するように変更しました。
今後もバージョンはなるべく早く追従するべきですが、少なくともこちらが指定したタイミングでアップデートできるようになるはずです。