### PR TITLE
Update Vivliostyle CLI (5.2.0) and Viewer (2.15.6)

### DIFF
--- a/cloud-run/Dockerfile
+++ b/cloud-run/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/vivliostyle/cli:5.1.0
+FROM ghcr.io/vivliostyle/cli:5.2.0
 LABEL maintainer "Vivliostyle Foundation <mail@vivliostyle.org>"
 
 RUN set -x \

--- a/web/package.json
+++ b/web/package.json
@@ -23,7 +23,7 @@
     "@octokit/graphql": "^4.8.0",
     "@octokit/rest": "^18.12.0",
     "@vivliostyle/vfm": "1.2.2",
-    "@vivliostyle/viewer": "2.15.5",
+    "@vivliostyle/viewer": "2.15.6",
     "apollo-server-micro": "^3.6.2",
     "chakra-ui-contextmenu": "^1.0.3",
     "dotenv": "^14.3.2",

--- a/web/yarn.lock
+++ b/web/yarn.lock
@@ -3346,10 +3346,10 @@
     "@typescript-eslint/types" "5.8.0"
     eslint-visitor-keys "^3.0.0"
 
-"@vivliostyle/core@^2.15.5":
-  version "2.15.5"
-  resolved "https://registry.yarnpkg.com/@vivliostyle/core/-/core-2.15.5.tgz#53bd3de7ec01c055b8e11d95105b85db9114fd6c"
-  integrity sha512-9XHElXfxhvHCXXSi+W+wo6NqUDZDDRIwuvteKS5vPu0LYUQhe66InaqZVpUwLoQJqmZCaDEN+bKrBIvBFx/OHw==
+"@vivliostyle/core@^2.15.6":
+  version "2.15.6"
+  resolved "https://registry.yarnpkg.com/@vivliostyle/core/-/core-2.15.6.tgz#68ad93def827c672933b6e336228c87fa3158377"
+  integrity sha512-QPdbxBXVzKSb3Hjp5btmJZeuVg7RHUxjgBtOw69qBC4vdeTgScHCmVxw3DLbn5HQhmLYD5q/nvbEvClTfwkxhw==
   dependencies:
     fast-diff "^1.2.0"
 
@@ -3392,12 +3392,12 @@
     unist-util-visit "^2.0.3"
     unist-util-visit-parents "^3.1.1"
 
-"@vivliostyle/viewer@2.15.5":
-  version "2.15.5"
-  resolved "https://registry.yarnpkg.com/@vivliostyle/viewer/-/viewer-2.15.5.tgz#a61f8c8e1b39948a2215e315c3c50e13ae7a30f4"
-  integrity sha512-cUbTQfZpPHSB/rfULE45yGuv2ny9NGSUceajkDkP/0ckELa8gQui+BXHJ/clG1ARfQIZpOknbVstkHTkCnxgog==
+"@vivliostyle/viewer@2.15.6":
+  version "2.15.6"
+  resolved "https://registry.yarnpkg.com/@vivliostyle/viewer/-/viewer-2.15.6.tgz#b87678c7e29e85618b5bd2e22c98a4855f0febbc"
+  integrity sha512-GbUPQwyaBQkiXZs9qKS2tIbVDJ6J+W+hOr4UrG9yTOJ7N7v84OOytcws/XDWbvoUf/ha+aRkGEsH2/8MUL07vw==
   dependencies:
-    "@vivliostyle/core" "^2.15.5"
+    "@vivliostyle/core" "^2.15.6"
     font-awesome "^4.7.0"
     knockout "^3.5.0"
 


### PR DESCRIPTION
PDF出力で標準で使えるフォントの改善 https://github.com/vivliostyle/vivliostyle-cli/pull/310 など
